### PR TITLE
Use github secrets for email

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -8,5 +8,5 @@ NODE_ENV=production
 # Email Configuration
 EMAIL_HOST=smtp.hostinger.com
 EMAIL_PORT=465
-EMAIL_USER=contact@porotein.fr
-EMAIL_PASSWORD=spycW6$HSyE*N$BWbaW^1zWV
+EMAIL_USER=${{ secrets.EMAIL_ADDRESS }}
+EMAIL_PASSWORD=${{ secrets.EMAIL_PASSWORD }}


### PR DESCRIPTION
## Summary
- swap out raw email credentials for GitHub Secrets in `api/.env`

## Testing
- `pnpm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_685432204820832a8eba6139e626da45